### PR TITLE
Changed behavior of insert function.

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -13,7 +13,7 @@ void buffer_init(buffer_t *bp)
 	bp->b_page = 0;
 	bp->b_epage = 0;
 	bp->b_size = 0;
-	bp->b_psize = 0;	
+	bp->b_psize = 0;
 	bp->b_flags = 0;
 	bp->b_cnt = 0;
 	bp->b_buf = NULL;
@@ -34,7 +34,7 @@ buffer_t *find_buffer (char *bname, int cflag)
 {
 	buffer_t *bp = NULL;
 	buffer_t *sb = NULL;
-	
+
 	bp = bheadp;
 	while (bp != NULL) {
 		if (strcmp(bname, bp->b_bname) == 0) {
@@ -61,7 +61,7 @@ buffer_t *find_buffer (char *bname, int cflag)
 			for (sb = bheadp; sb->b_next != NULL; sb = sb->b_next)
 				if (strcmp (sb->b_next->b_bname, bname) > 0)
 					break;
-			
+
 			/* and insert it */
 			bp->b_next = sb->b_next;
 			sb->b_next = bp;
@@ -86,7 +86,7 @@ int delete_buffer (buffer_t *bp)
 
 	/* we must have switched to a different buffer first */
 	assert(bp != curbp);
-	
+
 	/* if buffer is the head buffer */
 	if (bp == bheadp) {
 		bheadp = bp->b_next;
@@ -108,7 +108,7 @@ void next_buffer()
 {
 	assert(curbp != NULL);
 	assert(bheadp != NULL);
-	disassociate_b(curwp);	
+	disassociate_b(curwp);
 	curbp = (curbp->b_next != NULL ? curbp->b_next : bheadp);
 	associate_b2w(curbp,curwp);
 }
@@ -151,7 +151,7 @@ int delete_buffer_byname(char *bname)
 {
 	buffer_t *bp = find_buffer(bname, FALSE);
 	int bcount = count_buffers();
-	
+
 	if (bp == NULL) return FALSE;
 
 	/* if last buffer, create a scratch buffer */
@@ -162,7 +162,7 @@ int delete_buffer_byname(char *bname)
 	/* switch out of buffer if we are the current buffer */
 	if (bp == curbp)
 		next_buffer();
-	assert(bp != curbp);	
+	assert(bp != curbp);
 	delete_buffer(bp);
 	return TRUE;
 }
@@ -174,7 +174,7 @@ int select_buffer(char *bname)
 
 	assert(bp != NULL);
 	assert(curbp != NULL);
-	
+
 	disassociate_b(curwp);
 	curbp = bp;
 	associate_b2w(curbp,curwp);
@@ -207,7 +207,7 @@ void list_buffers()
 	char blank[] = " ";
 	char *bn;
 	char *fn;
-	
+
 	list_bp = find_buffer(str_buffers, TRUE);
 	strcpy(list_bp->b_bname, str_buffers);
 
@@ -219,10 +219,10 @@ void list_buffers()
 	/*             12 1234567 12345678901234567 */
 	insert_string("CO    Size Buffer           File\n");
 	insert_string("-- ------- ------           ----\n");
-		
+
 	bp = bheadp;
 	while (bp != NULL) {
-		if (bp != list_bp) {
+	  if (bp != list_bp) {
 			mod_ch  = ((bp->b_flags & B_MODIFIED) ? '*' : ' ');
 			over_ch = ((bp->b_flags & B_OVERWRITE) ? 'O' : ' ');
 			bn = (bp->b_bname[0] != '\0' ? bp->b_bname : blank);

--- a/header.h
+++ b/header.h
@@ -18,13 +18,19 @@
 #undef _
 #define _(x)    x
 
+
+typedef enum {
+        B_MODIFIED = 0x01,
+	B_OVERWRITE = 0x02,		/* overwite mode */
+	B_SPECIAL = 0x04,		/* <! For Special Buffers */
+} buffer_flags_t;
+
+
 #define VERSION	 "FemtoEmacs 1.5, Public Domain, 2016"
 #define EXIT_OK         0               /* Success */
 #define EXIT_ERROR      1               /* Unknown error. */
 #define EXIT_USAGE      2               /* Usage */
 #define EXIT_FAIL       3               /* Known failure. */
-#define B_MODIFIED	0x01		/* modified buffer */
-#define B_OVERWRITE	0x02		/* overwite mode */
 #define MSGLINE         (LINES-1)
 #define NOMARK          -1
 #define NOPAREN         -1
@@ -58,7 +64,7 @@ typedef long point_t;
 typedef struct pscrap_t {
         char_t *scrap;
         struct pscrap_t *next;
-} pscrap_t;	
+} pscrap_t;
 
 typedef struct keymap_t {
 	char *key_name;			/* the name of the key, for exmaple 'C-x a' */
@@ -122,7 +128,7 @@ extern window_t *wheadp;
 
 /*
  * Some compilers define size_t as a unsigned 16 bit number while
- * point_t and off_t might be defined as a signed 32 bit number.  
+ * point_t and off_t might be defined as a signed 32 bit number.
  * malloc(), realloc(), fread(), and fwrite() take size_t parameters,
  * which means there will be some size limits because size_t is too
  * small of a type.
@@ -316,7 +322,6 @@ extern char_t* ps_top(pscrap_t *st);
 extern int ps_size(pscrap_t *st);
 
 /*
- * include public Femto interface functions definitions 
+ * include public Femto interface functions definitions
  */
 #include "public.h"
-

--- a/main.c
+++ b/main.c
@@ -3,6 +3,9 @@
  * Derived from: Anthony's Editor January 93, (Public Domain 1991, 1993 by Anthony Howe)
  */
 
+
+#include <string.h> /* For strcpy () */
+
 #include "header.h"
 
 int main(int argc, char **argv)
@@ -10,8 +13,8 @@ int main(int argc, char **argv)
 	int i;
 	char *flargv[10];
 	flargv[0]= (char *)malloc(300);
-	flargv[1]= (char *)malloc(300);		
-	
+	flargv[1]= (char *)malloc(300);
+
 	/* Find basename. */
 	prog_name = *argv;
 	i = strlen(prog_name);
@@ -49,6 +52,8 @@ int main(int argc, char **argv)
 		strcpy(curbp->b_fname, temp);
 	} else {
 		curbp = find_buffer(str_scratch, TRUE);
+		strcpy (curbp->b_bname, "*scratch*");
+		curbp->b_flags = B_SPECIAL;
 	}
 
 	wheadp = curwp = new_window();
@@ -59,20 +64,20 @@ int main(int argc, char **argv)
 	undoset();
 	key_map = keymap;
 	initLisp(1, flargv);
-	
+
 	while (!done) {
 		update_display();
 		input = get_key(key_map, &key_return);
 
 		if (key_return != NULL) {
-			whatKey= key_return->key_name;			
+			whatKey= key_return->key_name;
 			(key_return->func)();
 		} else {
 			/*
 			 * if first char of input is a control char then
 			 * key is not bound, except TAB and NEWLINE
 			 */
-			 
+
 			if (*input > 31 || *input == 0x0A || *input == 0x09)
 			  insert();
                         else
@@ -82,7 +87,7 @@ int main(int argc, char **argv)
 		/* debug_stats("main loop:"); */
 		match_parens();
 	}
-	
+
 	if (scrap != NULL)
 		free(scrap);
 

--- a/replace.c
+++ b/replace.c
@@ -17,7 +17,7 @@ void query_replace(void)
 
 	searchtext[0] = '\0';
 	replace[0] = '\0';
-	
+
 	if (!getinput(m_replace, (char*)searchtext, STRBUF_M))
 		return;
 
@@ -26,7 +26,7 @@ void query_replace(void)
 
 	slen = strlen(searchtext);
 	rlen = strlen(replace);
-	
+
 	/* build query replace question string */
 	sprintf(question, m_qreplace, searchtext, replace);
 
@@ -48,7 +48,7 @@ void query_replace(void)
 		if (ask == TRUE) {
 			msg(question);
 			clrtoeol();
-			
+
 		qprompt:
 			display(curwp, TRUE);
 			c = getch();
@@ -56,15 +56,15 @@ void query_replace(void)
 			switch (c) {
 			case 'y': /* yes, substitute */
 				break;
-			
+
 			case 'n': /* no, find next */
 				curbp->b_point = found; /* set to end of search string */
 				continue;
-			
+
 			case '!': /* yes/stop asking, do the lot */
 				ask = FALSE;
 				break;
-			
+
 			case 0x1B: /* esc */
 				flushinp(); /* discard any escape sequence without writing in buffer */
 			case 'q': /* controlled exit */
@@ -75,7 +75,7 @@ void query_replace(void)
 				goto qprompt;
 			}
 		}
-		
+
 		if (rlen > slen) {
 			movegap(curbp, found);
 			/*check enough space in gap left */
@@ -88,13 +88,14 @@ void query_replace(void)
 			/* stretch gap left by s - r, no need to worry about space */
 			curbp->b_gap = curbp->b_gap - (slen - rlen);
 		} else {
-			/* if rlen = slen, we just overwrite the chars, no need to move gap */		
+			/* if rlen = slen, we just overwrite the chars, no need to move gap */
 		}
 
 		/* now just overwrite the chars at point in the buffer */
 		l_point = curbp->b_point;
 		memcpy(ptr(curbp, curbp->b_point), replace, rlen * sizeof (char_t));
-		curbp->b_flags |= B_MODIFIED;
+		if (!(curbp->b_flags & B_SPECIAL))
+		  curbp->b_flags |= B_MODIFIED;
 		curbp->b_point = found - (slen - rlen); /* end of replcement */
 		numsub++;
 	}


### PR DESCRIPTION
**Emacs** has the concept of _special buffers_, these kind of buffers
do not have a file associated to it and their name follow this
pattern `*<buffer-name>*`, for instance `*frobz*` is a
_special buffer_.

If a user opens **Emacs** and starts typing text on the `*scratch*`
_buffer_ and then hits <kbd>C-x C-c</kbd> **Emacs** does ask him
to save the file.

This commit added some minor changes to enable this behavior in
**FemtoEmacs**.
- Moved `B_MODIFIED` and `B_OVERWRITE` into a `enum`.
- Added a additional flag (`B_SPECIAL`) for _buffers_,
  this flag specifies wheter a buffer is special or not.
